### PR TITLE
Update operators to version 0.3.3

### DIFF
--- a/hazelcast-enterprise-operator/hazelcast-full.yaml
+++ b/hazelcast-enterprise-operator/hazelcast-full.yaml
@@ -11,6 +11,10 @@ spec:
   ## ref: https://hub.docker.com/r/hazelcast/hazelcast-enterprise-kubernetes/tags/
   ##
   image:
+    # repository is the Hazelcast image name
+    repository: "hazelcast/hazelcast-enterprise"
+    # tag is the Hazelcast image tag
+    tag: "4.0.3"
     # pullPolicy is the Docker image pull policy
     # It's recommended to change this to 'Always' if the image tag is 'latest'
     # ref: http://kubernetes.io/docs/user-guide/images/#updating-images
@@ -240,7 +244,7 @@ spec:
       # repository is the Hazelcast Management Center image name
       repository: "hazelcast/management-center"
       # tag is the Hazelcast Management Center image tag
-      tag: "3.12.12"
+      tag: "4.2020.08"
       # pullPolicy is the Docker image pull policy
       # It's recommended to change this to 'Always' if the image tag is 'latest'
       # ref: http://kubernetes.io/docs/user-guide/images/#updating-images

--- a/hazelcast-enterprise-operator/hazelcast.yaml
+++ b/hazelcast-enterprise-operator/hazelcast.yaml
@@ -7,8 +7,9 @@ metadata:
     app.kubernetes.io/instance: hazelcast
     app.kubernetes.io/managed-by: hazelcast-enterprise-operator
 spec:
-  cluster:
-    memberCount: 3
+  image:
+    repository: "hazelcast/hazelcast-enterprise"
+    tag: 4.0.3
   service:
     create: true
     type: ClusterIP
@@ -35,6 +36,9 @@ spec:
     runAsGroup: ""
     fsGroup: ""
   mancenter:
+    image:
+      repository: "hazelcast/management-center"
+      tag: 4.2020.08
     service:
       type: LoadBalancer
       port: 8080

--- a/hazelcast-enterprise-operator/operator-docker-hub.yaml
+++ b/hazelcast-enterprise-operator/operator-docker-hub.yaml
@@ -20,7 +20,7 @@ spec:
       annotations:
         productID: hazelcast-enterprise-operator
         productName: Hazelcast Operator
-        productVersion: 0.3.2
+        productVersion: 0.3.3
     spec:
       serviceAccountName: hazelcast-enterprise-operator
       securityContext:
@@ -38,7 +38,7 @@ spec:
                 - amd64
       containers:
         - name: hazelcast-enterprise-operator
-          image: hazelcast/hazelcast-enterprise-operator:0.3.2
+          image: hazelcast/hazelcast-enterprise-operator:0.3.3
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
@@ -51,10 +51,14 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "hazelcast-enterprise-operator"
-            - name: RELATED_IMAGE_HAZELCAST
-              value: hazelcast/hazelcast-enterprise:4.0.2
-            - name: RELATED_IMAGE_MANCENTER
-              value: hazelcast/management-center:4.2020.08
+            - name: HAZELCAST_IMAGE_REPOSITORY
+              value: hazelcast/hazelcast-enterprise
+            - name: HAZELCAST_IMAGE_TAG
+              value: 4.0.3
+            - name: MC_IMAGE_REPOSITORY
+              value: hazelcast/management-center
+            - name: MC_IMAGE_TAG
+              value: 4.2020.08
           resources:
             limits:
               cpu: "0.1"

--- a/hazelcast-enterprise-operator/operator-rhel.yaml
+++ b/hazelcast-enterprise-operator/operator-rhel.yaml
@@ -20,7 +20,7 @@ spec:
       annotations:
         productID: hazelcast-enterprise-operator
         productName: Hazelcast Enterprise Operator
-        productVersion: 0.3.2
+        productVersion: 0.3.3
     spec:
       serviceAccountName: hazelcast-enterprise-operator
       securityContext:
@@ -38,7 +38,7 @@ spec:
                 - amd64
       containers:
         - name: hazelcast-enterprise-operator
-          image: registry.connect.redhat.com/hazelcast/hazelcast-enterprise-operator:0.3.2
+          image: registry.connect.redhat.com/hazelcast/hazelcast-enterprise-operator:0.3.3
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
@@ -51,10 +51,14 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "hazelcast-enterprise-operator"
-            - name: RELATED_IMAGE_HAZELCAST
-              value: registry.connect.redhat.com/hazelcast/hazelcast-enterprise-4-rhel8:4.0.2
-            - name: RELATED_IMAGE_MANCENTER
-              value: registry.connect.redhat.com/hazelcast/management-center-4-rhel8:4.2020.08-1
+            - name: HAZELCAST_IMAGE_REPOSITORY
+              value: registry.connect.redhat.com/hazelcast/hazelcast-enterprise-4-rhel8
+            - name: HAZELCAST_IMAGE_TAG
+              value: 4.0.3-1
+            - name: MC_IMAGE_REPOSITORY
+              value: registry.connect.redhat.com/hazelcast/management-center-4-rhel8
+            - name: MC_IMAGE_TAG
+              value: 4.2020.08-1
           resources:
             limits:
               cpu: "0.1"

--- a/hazelcast-operator/hazelcast-full.yaml
+++ b/hazelcast-operator/hazelcast-full.yaml
@@ -11,6 +11,10 @@ spec:
   ## ref: https://hub.docker.com/r/hazelcast/hazelcast-kubernetes/tags/
   ##
   image:
+    # repository is the Hazelcast image name
+    repository: "hazelcast/hazelcast"
+    # tag is the Hazelcast image tag
+    tag: "4.0.3"
     # pullPolicy is the Docker image pull policy
     # It's recommended to change this to 'Always' if the image tag is 'latest'
     # ref: http://kubernetes.io/docs/user-guide/images/#updating-images
@@ -205,7 +209,7 @@ spec:
       # repository is the Hazelcast Management Center image name
       repository: "hazelcast/management-center"
       # tag is the Hazelcast Management Center image tag
-      tag: "3.12.12"
+      tag: "4.2020.08"
       # pullPolicy is the Docker image pull policy
       # It's recommended to change this to 'Always' if the image tag is 'latest'
       # ref: http://kubernetes.io/docs/user-guide/images/#updating-images

--- a/hazelcast-operator/hazelcast.yaml
+++ b/hazelcast-operator/hazelcast.yaml
@@ -7,8 +7,9 @@ metadata:
     app.kubernetes.io/instance: hazelcast
     app.kubernetes.io/managed-by: hazelcast-operator
 spec:
-  cluster:
-    memberCount: 3
+  image:
+    repository: "hazelcast/hazelcast"
+    tag: 4.0.3
   service:
     create: true
     type: ClusterIP
@@ -33,6 +34,10 @@ spec:
     runAsGroup: ""
     fsGroup: ""
   mancenter:
+    image:
+      repository: "hazelcast/management-center"
+      tag: 4.2020.08
+    enabled: true
     service:
       type: LoadBalancer
       port: 8080

--- a/hazelcast-operator/operator.yaml
+++ b/hazelcast-operator/operator.yaml
@@ -20,7 +20,7 @@ spec:
       annotations:
         productID: hazelcast-operator
         productName: Hazelcast Operator
-        productVersion: 0.3.2
+        productVersion: 0.3.3
     spec:
       serviceAccountName: hazelcast-operator
       securityContext:
@@ -38,7 +38,7 @@ spec:
                 - amd64
       containers:
         - name: hazelcast-operator
-          image: hazelcast/hazelcast-operator:0.3.2
+          image: hazelcast/hazelcast-enterprise:0.3.3
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
@@ -50,11 +50,15 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
-              value: "hazelcast-operator"
-            - name: RELATED_IMAGE_HAZELCAST
-              value: hazelcast/hazelcast:4.0.2
-            - name: RELATED_IMAGE_MANCENTER
-              value: hazelcast/management-center:4.2020.08
+              value: hazelcast-operator
+            - name: HAZELCAST_IMAGE_REPOSITORY
+              value: hazelcast/hazelcast-enterprise
+            - name: HAZELCAST_IMAGE_TAG
+              value: 4.0.3
+            - name: MC_IMAGE_REPOSITORY
+              value: hazelcast/management-center
+            - name: MC_IMAGE_TAG
+              value: 4.2020.08
           resources:
             limits:
               cpu: "0.1"


### PR DESCRIPTION
 - Image name and tag can be configurable from CR YAML.
 - re-added image config into full-yamls

- [x] Update `operator-rhel.yaml` after release RHEL based operator