### PR TITLE
[Merge with 0.3.4] Update CRD apiversion to v1

### DIFF
--- a/hazelcast-enterprise-operator/hazelcastcluster.crd.yaml
+++ b/hazelcast-enterprise-operator/hazelcastcluster.crd.yaml
@@ -1,11 +1,7 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: hazelcastenterprises.hazelcast.com
-  labels:
-    app.kubernetes.io/name: hazelcast
-    app.kubernetes.io/instance: hazelcast
-    app.kubernetes.io/managed-by: hazelcast-enterprise-operator
 spec:
   group: hazelcast.com
   names:
@@ -14,10 +10,13 @@ spec:
     plural: hazelcastenterprises
     singular: hazelcastenterprise
   scope: Namespaced
-  subresources:
-    status: {}
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/hazelcast-operator/hazelcastcluster.crd.yaml
+++ b/hazelcast-operator/hazelcastcluster.crd.yaml
@@ -1,11 +1,7 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: hazelcasts.hazelcast.com
-  labels:
-    app.kubernetes.io/name: hazelcast
-    app.kubernetes.io/instance: hazelcast
-    app.kubernetes.io/managed-by: hazelcast-operator
 spec:
   group: hazelcast.com
   names:
@@ -14,10 +10,13 @@ spec:
     plural: hazelcasts
     singular: hazelcast
   scope: Namespaced
-  subresources:
-    status: {}
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
fixes #25 

@mtyazici, you need to add  `--crd-version=v1` flag fot `operator-sdk new` command at release actions:
`operator-sdk new  OPERATOR_NAME --api-version=hazelcast.com/v1alpha1 --crd-version=v1 ...`