### PR TITLE
Add Slack notification action to workflows

### DIFF
--- a/.github/workflows/hz-enterprise-op.-rhel-release.yaml
+++ b/.github/workflows/hz-enterprise-op.-rhel-release.yaml
@@ -28,7 +28,8 @@ on:
         default: '60'
 
 jobs:
-  build:
+  build_publish:
+    name: Build and Publish
     defaults:
       run:
         shell: bash
@@ -375,3 +376,20 @@ jobs:
           gh pr create \
               --title "Update versions after release of RHEL ${OPERATOR_IMAGE}" \
               --body "Released ${OPERATOR_IMAGE} on RHEL. New operator and operator-bundle images are released on RHEL registry. "
+
+
+  slack_notify:
+    name: Slack Notify
+    needs: build_publish 
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - uses: 8398a7/action-slack@v3
+        if: needs.build_publish.result != 'success'
+        with:
+          fields: repo,commit,author,action,eventName,workflow
+          status: ${{ needs.build_publish.result }}
+          channel: '#github-actions-log'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/hz-enterprise-op.-rhel-release.yaml
+++ b/.github/workflows/hz-enterprise-op.-rhel-release.yaml
@@ -384,7 +384,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - uses: 8398a7/action-slack@v3
+      - uses: 8398a7/action-slack@f3635935f58910a6d6951b73efe9037c960c8c04
         if: needs.build_publish.result != 'success'
         with:
           fields: repo,commit,author,action,eventName,workflow

--- a/.github/workflows/hz-enterprise-op.-rhel-release.yaml
+++ b/.github/workflows/hz-enterprise-op.-rhel-release.yaml
@@ -391,5 +391,4 @@ jobs:
           status: ${{ needs.build_publish.result }}
           channel: '#github-actions-log'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/hz-op-dockerhub-release.yml
+++ b/.github/workflows/hz-op-dockerhub-release.yml
@@ -28,7 +28,8 @@ on:
         default: '4.2020.12'
 
 jobs:
-  build:
+  build_publish:
+    name: Build and Publish
     defaults:
       run:
         shell: bash
@@ -369,16 +370,17 @@ jobs:
 
 
   slack_notify:
-    name: Slack
-    needs: build # set needs only last job except this job
+    name: Slack Notify
+    needs: build_publish 
     runs-on: ubuntu-latest
-    if: always() # set always
+    if: always()
     steps:
       - uses: 8398a7/action-slack@v3
+        if: needs.build_publish.result != 'success'
         with:
           fields: repo,commit,author,action,eventName,workflow
-          status: ${{ needs.build.result }}
+          status: ${{ needs.build_publish.result }}
+          channel: '#github-actions-log'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        if: env.WORKFLOW_CONCLUSION == 'failure' # notify only if failure

--- a/.github/workflows/hz-op-dockerhub-release.yml
+++ b/.github/workflows/hz-op-dockerhub-release.yml
@@ -375,7 +375,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - uses: 8398a7/action-slack@v3
+      - uses: 8398a7/action-slack@f3635935f58910a6d6951b73efe9037c960c8c04
         if: needs.build_publish.result != 'success'
         with:
           fields: repo,commit,author,action,eventName,workflow

--- a/.github/workflows/hz-op-dockerhub-release.yml
+++ b/.github/workflows/hz-op-dockerhub-release.yml
@@ -382,5 +382,4 @@ jobs:
           status: ${{ needs.build_publish.result }}
           channel: '#github-actions-log'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/hz-op-dockerhub-release.yml
+++ b/.github/workflows/hz-op-dockerhub-release.yml
@@ -366,3 +366,19 @@ jobs:
           echo ${{ secrets.DEVOPS_GITHUB_TOKEN }} | gh auth login --with-token
 
           ../operator-repo/.github/scripts/expect.sh
+
+
+  slack_notify:
+    name: Slack
+    needs: build # set needs only last job except this job
+    runs-on: ubuntu-latest
+    if: always() # set always
+    steps:
+      - uses: 8398a7/action-slack@v3
+        with:
+          fields: repo,commit,author,action,eventName,workflow
+          status: ${{ needs.build.result }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: env.WORKFLOW_CONCLUSION == 'failure' # notify only if failure


### PR DESCRIPTION
This PR adds Slack notification action to all the workflows.

If a workflow finishes unsuccessfully, it will create a web-hook for the Slack channel `github-actions-log`.