### PR TITLE
Revert apiextension version from v1 to v1beta1

### DIFF
--- a/.github/operator-release-files/operatorhub-bundle/hazelcastenterprises.hazelcast.com.crd.yaml
+++ b/.github/operator-release-files/operatorhub-bundle/hazelcastenterprises.hazelcast.com.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: hazelcastenterprises.hazelcast.com
@@ -10,13 +10,10 @@ spec:
     plural: hazelcastenterprises
     singular: hazelcastenterprise
   scope: Namespaced
+  version: v1alpha1
   versions:
   - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
-    subresources:
-      status: {}
+  subresources:
+    status: {}

--- a/.github/operator-release-files/operatorhub-bundle/hazelcasts.hazelcast.com.crd.yaml
+++ b/.github/operator-release-files/operatorhub-bundle/hazelcasts.hazelcast.com.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: hazelcasts.hazelcast.com
@@ -10,13 +10,10 @@ spec:
     plural: hazelcasts
     singular: hazelcast
   scope: Namespaced
+  version: v1alpha1
   versions:
   - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
-    subresources:
-      status: {}
+  subresources:
+    status: {}

--- a/.github/operator-release-files/rhel-operator-bundle/hazelcastenterprises.hazelcast.com.crd.yaml
+++ b/.github/operator-release-files/rhel-operator-bundle/hazelcastenterprises.hazelcast.com.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: hazelcastenterprises.hazelcast.com
@@ -10,13 +10,10 @@ spec:
     plural: hazelcastenterprises
     singular: hazelcastenterprise
   scope: Namespaced
+  version: v1alpha1
   versions:
   - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
-    subresources:
-      status: {}
+  subresources:
+    status: {}

--- a/.github/workflows/hz-enterprise-op.-rhel-release.yaml
+++ b/.github/workflows/hz-enterprise-op.-rhel-release.yaml
@@ -144,7 +144,7 @@ jobs:
           echo "RHEL_BUNDLE_IMAGE=${RHEL_BUNDLE_IMAGE}" >> $GITHUB_ENV
 
           /operator-sdk init --plugins=helm --domain=''
-          /operator-sdk create api version=v1alpha1 --group=hazelcast.com --crd-version=v1 --kind=${KIND} --helm-chart=$(pwd)/${NAME}
+          /operator-sdk create api version=v1alpha1 --group=hazelcast.com --crd-version=v1beta1 --kind=${KIND} --helm-chart=$(pwd)/${NAME}
 
           cat >> watches.yaml <<EOL
             overrideValues:

--- a/.github/workflows/hz-op-dockerhub-release.yml
+++ b/.github/workflows/hz-op-dockerhub-release.yml
@@ -146,7 +146,7 @@ jobs:
           echo "OPERATOR_IMAGE=${OPERATOR_IMAGE}" >> $GITHUB_ENV
           
           /operator-sdk init --plugins=helm --domain=''
-          /operator-sdk create api version=v1alpha1 --group=hazelcast.com --crd-version=v1 --kind=${KIND} --helm-chart=$(pwd)/${NAME}
+          /operator-sdk create api version=v1alpha1 --group=hazelcast.com --crd-version=v1beta1 --kind=${KIND} --helm-chart=$(pwd)/${NAME}
 
           cat >> watches.yaml <<EOL
             overrideValues:

--- a/hazelcast-enterprise-operator/hazelcastcluster.crd.yaml
+++ b/hazelcast-enterprise-operator/hazelcastcluster.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: hazelcastenterprises.hazelcast.com
@@ -10,13 +10,10 @@ spec:
     plural: hazelcastenterprises
     singular: hazelcastenterprise
   scope: Namespaced
+  version: v1alpha1
   versions:
   - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
-    subresources:
-      status: {}
+  subresources:
+    status: {}

--- a/hazelcast-operator/hazelcastcluster.crd.yaml
+++ b/hazelcast-operator/hazelcastcluster.crd.yaml
@@ -10,13 +10,10 @@ spec:
     plural: hazelcasts
     singular: hazelcast
   scope: Namespaced
+  version: v1alpha1
   versions:
   - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
-    subresources:
-      status: {}
+  subresources:
+    status: {}


### PR DESCRIPTION
Reverts #27

This is needed because currently Red Hat doesn't certificate operator bundle images with apiextension version v1.