### PR TITLE
Add step for updating master branch of community operators fork

### DIFF
--- a/.github/workflows/hz-op-dockerhub-release.yml
+++ b/.github/workflows/hz-op-dockerhub-release.yml
@@ -327,6 +327,18 @@ jobs:
           token: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
 
 
+      - name: Update master branch of the fork
+        working-directory: community-operators
+        run: |
+          git checkout master
+
+          git remote add upstream https://github.com/operator-framework/community-operators.git 
+
+          git pull upstream master 
+
+          git push origin master
+
+
       - name: Create a PR for Operatorhub-bundle, path upstream-community-operators
         working-directory: community-operators
         run: |


### PR DESCRIPTION

Docker Hub release workflow creates PRs at the repository operator-framework/community-operators using the fork of devOpsHelm.

After the workflow has finished and operator version updating PRs for community-operators repository passes, the master branch of the devOpsHelm and operator-framework diverge. So when the workflow is run again and the second PR is created from the fork , the PR has conflicts with the master branch of the operator-framework repository. This PR fixes the issue.