### PR TITLE
Update Operator SDK and opm CLI version

### DIFF
--- a/.github/workflows/hz-enterprise-op-rhel-release.yaml
+++ b/.github/workflows/hz-enterprise-op-rhel-release.yaml
@@ -34,7 +34,7 @@ jobs:
       run:
         shell: bash
     env:
-      OPERATOR_SDK_VERSION: "v1.3.0"
+      OPERATOR_SDK_VERSION: "v1.7.2"
       KIND: "HazelcastEnterprise"
       NAME: "hazelcast-enterprise"
       REPO: "rhel"
@@ -66,10 +66,10 @@ jobs:
 
       - name: Install opm
         run: |
-          set -x
           sudo apt-get update
           sudo apt-get install --only-upgrade libc6
-          oc image extract quay.io/openshift/origin-operator-registry:4.6.0 --path /usr/bin/registry/opm:. --confirm
+          wget https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.7.10/opm-linux-4.7.10.tar.gz
+          tar xvf opm-linux-4.7.10.tar.gz
           chmod +x ./opm
           sudo mv opm /opm
           /opm version

--- a/.github/workflows/hz-op-dockerhub-release.yml
+++ b/.github/workflows/hz-op-dockerhub-release.yml
@@ -34,7 +34,7 @@ jobs:
       run:
         shell: bash
     env:
-      OPERATOR_SDK_VERSION: "v1.3.0"
+      OPERATOR_SDK_VERSION: "v1.7.2"
       NAME: ${{ github.event.inputs.NAME }}
       OPERATOR_VERSION: ${{ github.event.inputs.OPERATOR_VERSION }}
       PREVIOUS_OPERATOR_VERSION: ${{ github.event.inputs.PREVIOUS_OPERATOR_VERSION }}
@@ -44,6 +44,7 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
       HZ_ENTERPRISE_LICENSE: ${{ secrets.HZ_ENTERPRISE_LICENSE }}
+      
     runs-on: ubuntu-latest
     steps:
       - name: Install Operator-Sdk


### PR DESCRIPTION
Current Operator SDK version's base image contains vulnerabilities that Red Hat certification process doesn't accept. This update removes those vulnerabilities. Also, opm CLI has updated its preferred installation process. Now, workflow downloads the opm CLI from OpenShift mirror site.