### PR TITLE
Update Hazelcast-Enterprise for RHEL to version: 0.3.6

### DIFF
--- a/hazelcast-enterprise-operator/bundle-rhel.yaml
+++ b/hazelcast-enterprise-operator/bundle-rhel.yaml
@@ -156,7 +156,7 @@ spec:
       annotations:
         productID: hazelcast-enterprise-operator
         productName: Hazelcast Enterprise Operator
-        productVersion: 0.3.4-1
+        productVersion: 0.3.6
     spec:
       serviceAccountName: hazelcast-enterprise-operator
       securityContext:
@@ -174,7 +174,7 @@ spec:
                 - amd64
       containers:
         - name: hazelcast-enterprise-operator
-          image: registry.connect.redhat.com/hazelcast/hazelcast-enterprise-operator:0.3.4-1
+          image: registry.connect.redhat.com/hazelcast/hazelcast-enterprise-operator:0.3.6
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
@@ -188,9 +188,9 @@ spec:
             - name: OPERATOR_NAME
               value: "hazelcast-enterprise-operator"
             - name: RELATED_IMAGE_HAZELCAST
-              value: registry.connect.redhat.com/hazelcast/hazelcast-enterprise-4-rhel8:4.1.1
+              value: registry.connect.redhat.com/hazelcast/hazelcast-enterprise-4-rhel8:4.2
             - name: RELATED_IMAGE_MANCENTER
-              value: registry.connect.redhat.com/hazelcast/management-center-4-rhel8:4.2020.12-2
+              value: registry.connect.redhat.com/hazelcast/management-center-4-rhel8:4.2021.04
           resources:
             limits:
               cpu: "0.1"

--- a/hazelcast-enterprise-operator/operator-rhel.yaml
+++ b/hazelcast-enterprise-operator/operator-rhel.yaml
@@ -20,7 +20,7 @@ spec:
       annotations:
         productID: hazelcast-enterprise-operator
         productName: Hazelcast Enterprise Operator
-        productVersion: 0.3.5
+        productVersion: 0.3.6
     spec:
       serviceAccountName: hazelcast-enterprise-operator
       securityContext:
@@ -38,7 +38,7 @@ spec:
                 - amd64
       containers:
         - name: hazelcast-enterprise-operator
-          image: registry.connect.redhat.com/hazelcast/hazelcast-enterprise-operator:0.3.5
+          image: registry.connect.redhat.com/hazelcast/hazelcast-enterprise-operator:0.3.6
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
@@ -52,9 +52,9 @@ spec:
             - name: OPERATOR_NAME
               value: "hazelcast-enterprise-operator"
             - name: RELATED_IMAGE_HAZELCAST
-              value: registry.connect.redhat.com/hazelcast/hazelcast-enterprise-4-rhel8:4.1.2
+              value: registry.connect.redhat.com/hazelcast/hazelcast-enterprise-4-rhel8:4.2
             - name: RELATED_IMAGE_MANCENTER
-              value: registry.connect.redhat.com/hazelcast/management-center-4-rhel8:4.2021.03
+              value: registry.connect.redhat.com/hazelcast/management-center-4-rhel8:4.2021.04
           resources:
             limits:
               cpu: "0.1"


### PR DESCRIPTION
There was a missing update from the `0.3.5` version for the bundle file. It was still showing `0.3.4-1`, so I updated it directly to `0.3.6`,