### PR TITLE
[CN-108] Update Red Hat image publish script using new API

### DIFF
--- a/.github/scripts/publish-rhel.sh
+++ b/.github/scripts/publish-rhel.sh
@@ -64,7 +64,6 @@ wait_for_container_scan()
     for i in `seq 1 ${NOF_RETRIES}`; do
         local IMAGE=$(get_image not_published "$ID" "$VERSION" "$RHEL_API_KEY")
         local SCAN_STATUS=$(echo "$IMAGE" | jq -r '.data[0].scan_status')
-        echo $SCAN_STATUS
 
         if [ "${SCAN_STATUS}" = "in progress" ] || [ "${SCAN_STATUS}" = "null" ]; then
             echo "Scanning in progress, waiting..."
@@ -91,17 +90,16 @@ publish_the_image()
 
     # New API is using ID instead of PID unlike the previous one
     local ID=$(get_id_from_pid "$PROJECT_ID" "$RHEL_API_KEY")
-    echo 1
+
     local IS_PUBLISHED=$(get_image published "$ID" "$VERSION" "$RHEL_API_KEY" | jq -r '.total')
     if [ "$IS_PUBLISHED" = "1" ]; then
         echo "Image is already published, exiting"
         return 0
     fi
-    echo 2
+
     local IMAGE=$(get_image not_published "$ID" "$VERSION" "$RHEL_API_KEY")
     local IMAGE_ID=$(echo "$IMAGE" | jq -r '.data[0]._id')
-    echo $IMAGE_ID
-    echo 3
+
     # Publish the image
     echo "Publishing the image..."
     RESPONSE=$( \
@@ -112,7 +110,7 @@ publish_the_image()
             --header 'Content-Type: application/json' \
             --data "{\"image_id\":\"${IMAGE_ID}\" , \"tag\" : \"${VERSION}\" }" \
             "https://catalog.redhat.com/api/containers/v1/projects/certification/id/${ID}/requests/tags")
-    echo $RESPONSE
+
     STATUS=$(echo "${RESPONSE}" | jq -r '.status')
 
     if [ "$STATUS" = "pending" ]; then

--- a/.github/scripts/publish-rhel.sh
+++ b/.github/scripts/publish-rhel.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# We used to give project id in the queries but the new API asks for _ID field of the project.
 get_id_from_pid()
 {
     local PROJECT_ID=$1
@@ -23,9 +22,9 @@ get_image()
     local VERSION=$3
     local RHEL_API_KEY=$4
 
-    if [ ${PUBLISHED} = "published" ]; then
+    if [[ $PUBLISHED == "published" ]]; then
         local PUBLISHED_FILTER="repositories.published==true"
-    elif [ ${PUBLISHED} = "not_published" ]; then
+    elif [[ $PUBLISHED == "not_published" ]]; then
         local PUBLISHED_FILTER="repositories.published!=true"
     else
         echo "Need first parameter as 'published' or 'not_published'." ; return 1
@@ -50,11 +49,11 @@ wait_for_container_scan()
     local RHEL_API_KEY=$3
     local TIMEOUT_IN_MINS=$4
 
-    # New API is using ID instead of PID unlike the previous one
+    # Get ID of the PID from the API.
     local ID=$(get_id_from_pid "$PROJECT_ID" "$RHEL_API_KEY")
 
     local IS_PUBLISHED=$(get_image published "$ID" "$VERSION" "$RHEL_API_KEY" | jq -r '.total')
-    if [ "$IS_PUBLISHED" = "1" ]; then
+    if [[ $IS_PUBLISHED == "1" ]]; then
         echo "Image is already published, exiting"
         return 0
     fi
@@ -65,9 +64,9 @@ wait_for_container_scan()
         local IMAGE=$(get_image not_published "$ID" "$VERSION" "$RHEL_API_KEY")
         local SCAN_STATUS=$(echo "$IMAGE" | jq -r '.data[0].scan_status')
 
-        if [ "${SCAN_STATUS}" = "in progress" ] || [ "${SCAN_STATUS}" = "null" ]; then
+        if [[ $SCAN_STATUS == "in progress" ] || [[ $SCAN_STATUS == "null" ]]; then
             echo "Scanning in progress, waiting..."
-        elif [ "${SCAN_STATUS}" = "passed" ]; then
+        elif [[ $SCAN_STATUS == "passed" ]]; then
             echo "Scan passed!" ; return 0
         else
             echo "Scan failed!" ; return 1
@@ -75,7 +74,7 @@ wait_for_container_scan()
 
         sleep 120
 
-        if [ "$i" = "$NOF_RETRIES" ]; then
+        if [[ $i == $NOF_RETRIES ]]; then
             echo "Timeout! Scan could not be finished"
             return 42
         fi
@@ -88,11 +87,11 @@ publish_the_image()
     local VERSION=$2
     local RHEL_API_KEY=$3
 
-    # New API is using ID instead of PID unlike the previous one
+    # Get ID of the PID from the API.
     local ID=$(get_id_from_pid "$PROJECT_ID" "$RHEL_API_KEY")
 
     local IS_PUBLISHED=$(get_image published "$ID" "$VERSION" "$RHEL_API_KEY" | jq -r '.total')
-    if [ "$IS_PUBLISHED" = "1" ]; then
+    if [[ $IS_PUBLISHED == "1" ]]; then
         echo "Image is already published, exiting"
         return 0
     fi
@@ -113,9 +112,9 @@ publish_the_image()
 
     STATUS=$(echo "${RESPONSE}" | jq -r '.status')
 
-    if [ "$STATUS" = "pending" ]; then
+    if [[ $STATUS == "pending" ]]; then
         echo "Image publish status is pending!"
-    elif [ "$STATUS" = "success" ]; then
+    elif [[ $STATUS == "completed" ]]; then
         echo "Image publish was successful!"
     else
         echo "Image publish was unsuccessful!"

--- a/.github/workflows/hz-enterprise-op-rhel-release.yaml
+++ b/.github/workflows/hz-enterprise-op-rhel-release.yaml
@@ -322,6 +322,9 @@ jobs:
           source ./operator-repo/.github/scripts/publish-rhel.sh
 
           publish_the_image "$PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
+          
+          # We need to wait for operator image publish to be able to push operator bundle image
+          wait_for_container_publish "$PROJECT_ID" "$VERSION" "$RHEL_API_KEY" "$TIMEOUT_IN_MINS"
 
 
       - name: Push Operator-Bundle image to RHEL scan registry

--- a/.github/workflows/hz-enterprise-op-rhel-release.yaml
+++ b/.github/workflows/hz-enterprise-op-rhel-release.yaml
@@ -217,7 +217,7 @@ jobs:
           VERSION=${OPERATOR_VERSION}
           source ./operator-repo/.github/scripts/publish-rhel.sh
 
-          wait_for_container_build_or_scan $TIMEOUT_IN_MINS
+          wait_for_container_scan "$PROJECT_ID" "$VERSION" "$RHEL_API_KEY" "$TIMEOUT_IN_MINS"
 
 
       - name: Deploy Hazelcast Cluster
@@ -321,8 +321,7 @@ jobs:
           VERSION=${OPERATOR_VERSION}
           source ./operator-repo/.github/scripts/publish-rhel.sh
 
-          wait_for_container_build_or_scan $TIMEOUT_IN_MINS
-          publish_the_image
+          publish_the_image "$PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
 
 
       - name: Push Operator-Bundle image to RHEL scan registry
@@ -337,8 +336,9 @@ jobs:
           VERSION=${OPERATOR_VERSION}
           source ./operator-repo/.github/scripts/publish-rhel.sh
 
-          wait_for_container_build_or_scan $TIMEOUT_IN_MINS
-          publish_the_image
+          wait_for_container_scan "$PROJECT_ID" "$VERSION" "$RHEL_API_KEY" "$TIMEOUT_IN_MINS"
+          publish_the_image "$PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
+
 
 
       - name: Update Hazelcast Versions in the Repo


### PR DESCRIPTION
Red Hat changed their [ old API](https://connect.redhat.com/api-docs) to the new one [here](https://catalog.redhat.com/api/containers/v1/ui/). I updated our publish script accordingly.

Old functions were declaring and using global variables which other functions could also use. This was causing confusion.  I updated the functions so that they do not use or declare any global variables making it a lot easier to track, test and debug.

TODO
===
- [x] ~~I was not able to test the `publish_the_image` function's success version as it seems they did not implement the tag publish endpoints yet. I am waiting a response from the Red Hat support team~~ I added the `publish_the_image` function but with the new API publish does not happen instantaneously. So I had to add a new function to wait for publish to finish before pushing the bundle image