### PR TITLE
[CN-148] Update operator-hub bundle release repositories.

### DIFF
--- a/.github/workflows/hz-op-dockerhub-release.yml
+++ b/.github/workflows/hz-op-dockerhub-release.yml
@@ -337,51 +337,71 @@ jobs:
         run: |
           git checkout master
 
-          git remote add upstream https://github.com/operator-framework/community-operators.git 
+          git remote add upstream https://github.com/k8s-operatorhub/community-operators.git
 
           git pull upstream master 
 
           git push origin master
 
 
-      - name: Create a PR for Operatorhub-bundle, path upstream-community-operators
+      - name: Create a PR for Operatorhub-bundle, K8s-operatorhub
         working-directory: community-operators
         run: |
-          export REPO_OWNER=operator-framework
+          export REPO_OWNER=K8s-operatorhub
           export REPO_NAME=community-operators
 
-          git checkout -b ${OPERATOR_NAME}-upstream-${OPERATOR_VERSION}-${{ github.run_id }}
+          git checkout -b ${OPERATOR_NAME}-${OPERATOR_VERSION}-${{ github.run_id }}
 
-          cp -r ../operatorhub-bundle-output/* ./upstream-community-operators/${OPERATOR_NAME}/
+          cp -r ../operatorhub-bundle-output/* ./operators/${OPERATOR_NAME}/
 
-          git add  ./upstream-community-operators/${OPERATOR_NAME}
+          git add  ./operators/${OPERATOR_NAME}
 
-          git commit --signoff -m "Update ${OPERATOR_NAME} to ${OPERATOR_VERSION} - upstream"
+          git commit --signoff -m "Update ${OPERATOR_NAME} to ${OPERATOR_VERSION}"
 
-          git push -u origin ${OPERATOR_NAME}-upstream-${OPERATOR_VERSION}-${{ github.run_id }}
+          git push -u origin ${OPERATOR_NAME}-${OPERATOR_VERSION}-${{ github.run_id }}
 
           echo ${{ secrets.DEVOPS_GITHUB_TOKEN }} | gh auth login --with-token
 
           ../operator-repo/.github/scripts/expect.sh
 
 
-      - name: Create a PR for Operatorhub-bundle, path community-operators
-        if: env.NAME != 'hazelcast-enterprise'
-        working-directory: community-operators
+      - name: Checkout to devOpsHelm/community-operators-prod
+        uses: actions/checkout@v2
+        with:
+          repository: devOpsHelm/community-operators-prod
+          path: community-operators-prod
+          token: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
+
+
+      - name: Update master branch of the fork
+        working-directory: community-operators-prod
         run: |
-          export REPO_OWNER=operator-framework
-          export REPO_NAME=community-operators
+          git checkout master
+
+          git remote add upstream https://github.com/redhat-openshift-ecosystem/community-operators-prod.git
+
+          git pull upstream master 
+
+          git push origin master
+
+
+      - name: Create a PR for Operatorhub-bundle, redhat-openshift-ecosystem
+        if: env.NAME == 'hazelcast'
+        working-directory: community-operators-prod
+        run: |
+          export REPO_OWNER=redhat-openshift-ecosystem
+          export REPO_NAME=community-operators-prod
 
           git checkout master
-          git checkout -b ${OPERATOR_NAME}-community-${OPERATOR_VERSION}-${{ github.run_id }}
+          git checkout -b ${OPERATOR_NAME}-${OPERATOR_VERSION}-${{ github.run_id }}
 
-          cp -r ../operatorhub-bundle-output/* ./community-operators/${OPERATOR_NAME}/
+          cp -r ../operatorhub-bundle-output/* ./operators/${OPERATOR_NAME}/
 
-          git add  ./community-operators/${OPERATOR_NAME}
+          git add  ./operators/${OPERATOR_NAME}
 
-          git commit --signoff -m "Update ${OPERATOR_NAME} to ${OPERATOR_VERSION} - community"
+          git commit --signoff -m "Update ${OPERATOR_NAME} to ${OPERATOR_VERSION}"
 
-          git push -u origin ${OPERATOR_NAME}-community-${OPERATOR_VERSION}-${{ github.run_id }}
+          git push -u origin ${OPERATOR_NAME}-${OPERATOR_VERSION}-${{ github.run_id }}
 
           echo ${{ secrets.DEVOPS_GITHUB_TOKEN }} | gh auth login --with-token
 

--- a/.github/workflows/hz-op-dockerhub-release.yml
+++ b/.github/workflows/hz-op-dockerhub-release.yml
@@ -344,10 +344,10 @@ jobs:
           git push origin main
 
 
-      - name: Create a PR for Operatorhub-bundle, K8s-operatorhub
+      - name: Create a PR for Operatorhub-bundle, k8s-operatorhub
         working-directory: community-operators
         run: |
-          export REPO_OWNER=K8s-operatorhub
+          export REPO_OWNER=k8s-operatorhub
           export REPO_NAME=community-operators
 
           git checkout -b ${OPERATOR_NAME}-${OPERATOR_VERSION}-${{ github.run_id }}

--- a/.github/workflows/hz-op-dockerhub-release.yml
+++ b/.github/workflows/hz-op-dockerhub-release.yml
@@ -332,16 +332,16 @@ jobs:
           token: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
 
 
-      - name: Update master branch of the fork
+      - name: Update main branch of the fork
         working-directory: community-operators
         run: |
-          git checkout master
+          git checkout main
 
           git remote add upstream https://github.com/k8s-operatorhub/community-operators.git
 
-          git pull upstream master 
+          git pull upstream main 
 
-          git push origin master
+          git push origin main
 
 
       - name: Create a PR for Operatorhub-bundle, K8s-operatorhub
@@ -373,16 +373,16 @@ jobs:
           token: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
 
 
-      - name: Update master branch of the fork
+      - name: Update main branch of the fork
         working-directory: community-operators-prod
         run: |
-          git checkout master
+          git checkout main
 
           git remote add upstream https://github.com/redhat-openshift-ecosystem/community-operators-prod.git
 
-          git pull upstream master 
+          git pull upstream main 
 
-          git push origin master
+          git push origin main
 
 
       - name: Create a PR for Operatorhub-bundle, redhat-openshift-ecosystem
@@ -392,7 +392,6 @@ jobs:
           export REPO_OWNER=redhat-openshift-ecosystem
           export REPO_NAME=community-operators-prod
 
-          git checkout master
           git checkout -b ${OPERATOR_NAME}-${OPERATOR_VERSION}-${{ github.run_id }}
 
           cp -r ../operatorhub-bundle-output/* ./operators/${OPERATOR_NAME}/


### PR DESCRIPTION
We used to push our operator bundles in the [operator-framework/community-operators](https://github.com/operator-framework/community-operators) repository. However, it became obsolete and we need to put our bundles in two different repositories:

1-  [k8s-operatorhub/community-operators](https://github.com/k8s-operatorhub/community-operators ): We will put bundles for Hazelcast Operator and Hazelcast Enterprise Operator here. They will be shown on operatorhub.io

2-  [redhat-openshift-ecosystem/community-operators-prod](https://github.com/redhat-openshift-ecosystem/community-operators-prod): We will put bundles for Hazelcast Operator here. It will be shown on OpenShift Container Platform and OKD.