### PR TITLE
Update KIND version to v0.11.1 in hz-op-dockerhub-release.yml

### DIFF
--- a/.github/workflows/hz-op-dockerhub-release.yml
+++ b/.github/workflows/hz-op-dockerhub-release.yml
@@ -193,7 +193,7 @@ jobs:
       - name: Set up Kubernetes in Docker
         uses: engineerd/setup-kind@v0.5.0
         with:
-          version: "v0.7.0"
+          version: "v0.11.1"
 
 
       - name: Deploy Hazelcast cluster


### PR DESCRIPTION
The version we were using now gives timeout errors, the version v0.11.1 works without a problem