### PR TITLE
[CN-158] Update CRD version to v1 for Hazelcast and HazelcastEnterprise CRs

### DIFF
--- a/.github/operator-release-files/operatorhub-bundle/hazelcast-enterprise-operator.vOPERATOR_VERSION.clusterserviceversion.yaml
+++ b/.github/operator-release-files/operatorhub-bundle/hazelcast-enterprise-operator.vOPERATOR_VERSION.clusterserviceversion.yaml
@@ -80,7 +80,7 @@ spec:
                 - watch
             - apiGroups:
               - ""
-              - "extensions"
+              - "networking.k8s.io"
               resources:
               - ingresses
               verbs:

--- a/.github/operator-release-files/operatorhub-bundle/hazelcast-operator.vOPERATOR_VERSION.clusterserviceversion.yaml
+++ b/.github/operator-release-files/operatorhub-bundle/hazelcast-operator.vOPERATOR_VERSION.clusterserviceversion.yaml
@@ -73,7 +73,7 @@ spec:
                 - watch
             - apiGroups:
               - ""
-              - "extensions"
+              - "networking.k8s.io"
               resources:
               - ingresses
               verbs:

--- a/.github/operator-release-files/operatorhub-bundle/hazelcastenterprises.hazelcast.com.crd.yaml
+++ b/.github/operator-release-files/operatorhub-bundle/hazelcastenterprises.hazelcast.com.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: hazelcastenterprises.hazelcast.com
@@ -10,10 +10,13 @@ spec:
     plural: hazelcastenterprises
     singular: hazelcastenterprise
   scope: Namespaced
-  version: v1alpha1
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-  subresources:
-    status: {}
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}

--- a/.github/operator-release-files/operatorhub-bundle/hazelcasts.hazelcast.com.crd.yaml
+++ b/.github/operator-release-files/operatorhub-bundle/hazelcasts.hazelcast.com.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: hazelcasts.hazelcast.com
@@ -10,10 +10,13 @@ spec:
     plural: hazelcasts
     singular: hazelcast
   scope: Namespaced
-  version: v1alpha1
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-  subresources:
-    status: {}
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}

--- a/.github/operator-release-files/rhel-operator-bundle/hazelcast-enterprise-operator.vOPERATOR_VERSION.clusterserviceversion.yaml
+++ b/.github/operator-release-files/rhel-operator-bundle/hazelcast-enterprise-operator.vOPERATOR_VERSION.clusterserviceversion.yaml
@@ -80,7 +80,7 @@ spec:
                 - watch
             - apiGroups:
               - ""
-              - "extensions"
+              - "networking.k8s.io"
               resources:
               - ingresses
               verbs:

--- a/.github/operator-release-files/rhel-operator-bundle/hazelcastenterprises.hazelcast.com.crd.yaml
+++ b/.github/operator-release-files/rhel-operator-bundle/hazelcastenterprises.hazelcast.com.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: hazelcastenterprises.hazelcast.com
@@ -10,10 +10,13 @@ spec:
     plural: hazelcastenterprises
     singular: hazelcastenterprise
   scope: Namespaced
-  version: v1alpha1
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-  subresources:
-    status: {}
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}

--- a/.github/workflows/hz-enterprise-op-rhel-release.yaml
+++ b/.github/workflows/hz-enterprise-op-rhel-release.yaml
@@ -3,29 +3,29 @@ on:
   workflow_dispatch:
     inputs:
       OPERATOR_VERSION:
-        description: 'OPERATOR_VERSION'
+        description: "OPERATOR_VERSION"
         required: true
-        default: '0.3.4'
+        default: "0.3.4"
       PREVIOUS_OPERATOR_VERSION:
-        description: 'PREVIOUS_OPERATOR_VERSION'
+        description: "PREVIOUS_OPERATOR_VERSION"
         required: true
-        default: '0.3.3'
+        default: "0.3.3"
       HELM_CHART_VERSION:
-        description: 'HELM_CHART_VERSION'
+        description: "HELM_CHART_VERSION"
         required: true
-        default: '3.5.2'
+        default: "3.5.2"
       HAZELCAST_VERSION:
-        description: 'HAZELCAST_VERSION'
+        description: "HAZELCAST_VERSION"
         required: true
-        default: '4.1.1'
+        default: "4.1.1"
       MANCENTER_VERSION:
-        description: 'MANCENTER_VERSION'
+        description: "MANCENTER_VERSION"
         required: true
-        default: '4.2020.12'
+        default: "4.2020.12"
       TIMEOUT_IN_MINS:
-        description: 'TIMEOUT_IN_MINS'
+        description: "TIMEOUT_IN_MINS"
         required: true
-        default: '60'
+        default: "60"
 
 jobs:
   build_publish:
@@ -53,7 +53,7 @@ jobs:
       RHEL_BUNDLE_PASSWORD: ${{ secrets.RHEL_BUNDLE_PASSWORD }}
       RHEL_REPOSITORY: ${{ secrets.RHEL_REPOSITORY }}
       RHEL_BUNDLE_REPOSITORY: ${{ secrets.RHEL_BUNDLE_REPOSITORY }}
-      RHEL_API_KEY:  ${{ secrets.RHEL_API_KEY }}
+      RHEL_API_KEY: ${{ secrets.RHEL_API_KEY }}
 
     runs-on: ubuntu-20.04
     steps:
@@ -62,7 +62,6 @@ jobs:
           sudo curl -L -o /operator-sdk "https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk_linux_amd64"
           sudo chmod +x /operator-sdk
           /operator-sdk version
-
 
       - name: Install opm
         run: |
@@ -74,12 +73,10 @@ jobs:
           sudo mv opm /opm
           /opm version
 
-
       - name: Checkout to hazelcast-operator
         uses: actions/checkout@v2
         with:
           path: operator-repo
-
 
       - name: Download Hazelcast Helm Chart
         run: |
@@ -92,7 +89,6 @@ jobs:
           fi
           tar xf ${NAME}-${HELM_CHART_VERSION}.tgz
           rm ${NAME}-${HELM_CHART_VERSION}.tgz
-
 
       - name: Overwrite template values
         working-directory: ./WORKDIR
@@ -134,7 +130,6 @@ jobs:
           name: updated-helm-charts
           path: ./WORKDIR/hazelcast-enterprise
 
-
       - name: Generate Operator and Operator Image
         working-directory: ./WORKDIR
         run: |
@@ -151,7 +146,7 @@ jobs:
           echo "RHEL_BUNDLE_IMAGE=${RHEL_BUNDLE_IMAGE}" >> $GITHUB_ENV
 
           /operator-sdk init --plugins=helm --domain=''
-          /operator-sdk create api version=v1alpha1 --group=hazelcast.com --crd-version=v1beta1 --kind=${KIND} --helm-chart=$(pwd)/${NAME}
+          /operator-sdk create api version=v1alpha1 --group=hazelcast.com --crd-version=v1 --kind=${KIND} --helm-chart=$(pwd)/${NAME}
 
           cat >> watches.yaml <<EOL
             overrideValues:
@@ -176,7 +171,6 @@ jobs:
           echo "Building the operator image ${OPERATOR_IMAGE}"
           make docker-build  IMG=${OPERATOR_IMAGE}
 
-
       - name: Update Hazelcast Enterprise Operator files
         run: |
           cp -r ./operator-repo/${OPERATOR_NAME}  ./
@@ -196,20 +190,17 @@ jobs:
           RHEL_HAZELCAST_REPO: registry.connect.redhat.com/hazelcast/hazelcast-enterprise-4-rhel8
           RHEL_MANCENTER_REPO: registry.connect.redhat.com/hazelcast/management-center-4-rhel8
 
-
       - name: Upload Hazelcast-enterprise-operator files
         uses: actions/upload-artifact@v2
         with:
           name: hazelcast-enterprise-operator
           path: ./hazelcast-enterprise-operator
 
-
       - name: Push Hazelcast-Enterprise-Operator image to RHEL scan registry
         run: |
           docker login ${SCAN_REGISTRY} -u unused -p ${RHEL_REPO_PASSWORD}
           docker tag ${OPERATOR_IMAGE} ${RHEL_IMAGE}
           docker push ${RHEL_IMAGE}
-
 
       - name: Wait for Scan to Complete
         run: |
@@ -218,7 +209,6 @@ jobs:
           source ./operator-repo/.github/scripts/publish-rhel.sh
 
           wait_for_container_scan "$PROJECT_ID" "$VERSION" "$RHEL_API_KEY" "$TIMEOUT_IN_MINS"
-
 
       - name: Deploy Hazelcast Cluster
         run: |
@@ -240,11 +230,9 @@ jobs:
           CLUSTER_SIZE: 3
           MANCENTER_SIZE: 1
 
-
       - name: Print log of the Hazelcast-Enterprise-Operator
         run: |
           kubectl logs -l app.kubernetes.io/name=${OPERATOR_NAME}
-
 
       - name: Validate Cluster Size
         run: |
@@ -263,7 +251,6 @@ jobs:
           CLUSTER_SIZE: 3
           MANCENTER_SIZE: 1
 
-
       - name: Clean up After Test
         if: always()
         run: |
@@ -271,11 +258,9 @@ jobs:
           PROJECT=operator-rhel-release-test-${{ github.run_id }}
           ./operator-repo/.github/scripts/clean-up.sh $WORKDIR $PROJECT
 
-
       - name: Copy rhel-operator-bundle from the repo
         run: |
           cp -r ./operator-repo/.github/operator-release-files/rhel-operator-bundle  ./
-
 
       - name: Build Operatorhub Bundle
         working-directory: .
@@ -307,13 +292,11 @@ jobs:
           echo "Building the RHEL-bundle image..."
           docker build -t ${RHEL_BUNDLE_IMAGE} -f bundle.Dockerfile .
 
-
       - name: Upload Operator-Bundle
         uses: actions/upload-artifact@v2
         with:
           name: hz-enterprise-rhel-operator-bundle
           path: ./rhel-operator-bundle
-
 
       - name: Publish the Hazelcast-Enterprise-Operator image
         run: |
@@ -322,16 +305,14 @@ jobs:
           source ./operator-repo/.github/scripts/publish-rhel.sh
 
           publish_the_image "$PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
-          
+
           # We need to wait for operator image publish to be able to push operator bundle image
           wait_for_container_publish "$PROJECT_ID" "$VERSION" "$RHEL_API_KEY" "$TIMEOUT_IN_MINS"
-
 
       - name: Push Operator-Bundle image to RHEL scan registry
         run: |
           docker login ${SCAN_REGISTRY} -u unused -p ${RHEL_BUNDLE_PASSWORD}
           docker push ${RHEL_BUNDLE_IMAGE}
-
 
       - name: Publish Operator-Bundle image
         run: |
@@ -341,8 +322,6 @@ jobs:
 
           wait_for_container_scan "$PROJECT_ID" "$VERSION" "$RHEL_API_KEY" "$TIMEOUT_IN_MINS"
           publish_the_image "$PROJECT_ID" "$VERSION" "$RHEL_API_KEY"
-
-
 
       - name: Update Hazelcast Versions in the Repo
         working-directory: ./operator-repo
@@ -361,7 +340,6 @@ jobs:
         env:
           REGISTRY_NAME: registry.connect.redhat.com/hazelcast
 
-
       - name: Commit changes done to Hazelcast-Operator
         working-directory: ./operator-repo
         run: |
@@ -376,7 +354,6 @@ jobs:
 
           git push -u origin $BRANCH_NAME
 
-
       - name: Create a PR for changes in Hazelcast-Operator
         working-directory: ./operator-repo
         run: |
@@ -385,10 +362,9 @@ jobs:
               --title "Update versions after release of RHEL ${OPERATOR_IMAGE}" \
               --body "Released ${OPERATOR_IMAGE} on RHEL. New operator and operator-bundle images are released on RHEL registry. "
 
-
   slack_notify:
     name: Slack Notify
-    needs: build_publish 
+    needs: build_publish
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -397,6 +373,6 @@ jobs:
         with:
           fields: repo,commit,author,action,eventName,workflow
           status: ${{ needs.build_publish.result }}
-          channel: '#github-actions-log'
+          channel: "#github-actions-log"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/hz-op-dockerhub-release.yml
+++ b/.github/workflows/hz-op-dockerhub-release.yml
@@ -3,29 +3,29 @@ on:
   workflow_dispatch:
     inputs:
       NAME:
-        description: 'NAME'
+        description: "NAME"
         required: true
-        default: 'hazelcast-enterprise'
+        default: "hazelcast-enterprise"
       OPERATOR_VERSION:
-        description: 'OPERATOR_VERSION'
+        description: "OPERATOR_VERSION"
         required: true
-        default: '0.3.4'
+        default: "0.3.4"
       PREVIOUS_OPERATOR_VERSION:
-        description: 'PREVIOUS_OPERATOR_VERSION'
+        description: "PREVIOUS_OPERATOR_VERSION"
         required: true
-        default: '0.3.3'
+        default: "0.3.3"
       HELM_CHART_VERSION:
-        description: 'HELM_CHART_VERSION'
+        description: "HELM_CHART_VERSION"
         required: true
-        default: '3.5.2'
+        default: "3.5.2"
       HAZELCAST_VERSION:
-        description: 'HAZELCAST_VERSION'
+        description: "HAZELCAST_VERSION"
         required: true
-        default: '4.1.1'
+        default: "4.1.1"
       MANCENTER_VERSION:
-        description: 'MANCENTER_VERSION'
+        description: "MANCENTER_VERSION"
         required: true
-        default: '4.2020.12'
+        default: "4.2020.12"
 
 jobs:
   build_publish:
@@ -44,7 +44,7 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
       HZ_ENTERPRISE_LICENSE: ${{ secrets.HZ_ENTERPRISE_LICENSE }}
-      
+
     runs-on: ubuntu-latest
     steps:
       - name: Install Operator-Sdk
@@ -53,19 +53,16 @@ jobs:
           sudo chmod +x /operator-sdk
           /operator-sdk version
 
-
       - name: Install expect
         run: |
           sudo apt-get update -y
           sudo apt-get install -y expect
           expect -version
 
-
       - name: Checkout to Hazelcast-Operator
         uses: actions/checkout@v2
         with:
           path: operator-repo
-
 
       - name: Download Hazelcast Helm Chart
         run: |
@@ -78,7 +75,6 @@ jobs:
           fi
           tar xf ${NAME}-${HELM_CHART_VERSION}.tgz
           rm ${NAME}-${HELM_CHART_VERSION}.tgz
-
 
       - name: Overwrite Helm-chart template files
         working-directory: ./WORKDIR
@@ -117,13 +113,11 @@ jobs:
           #FOR UPLOADING ARTIFACT
           cp -r ./${NAME} ./artifact-helm-charts
 
-
       - name: Upload updated Helm-Charts
         uses: actions/upload-artifact@v2
         with:
           name: updated-helm-charts
           path: ./WORKDIR/artifact-helm-charts
-
 
       - name: Set KIND and OPERATOR_YAML_NAME as environment variables
         run: |
@@ -137,10 +131,9 @@ jobs:
             echo "Wrong input type for name, it can be 'hazelcast' or 'hazelcast-enterprise'"
             exit 1
           fi
-          
+
           echo "KIND=${KIND}" >> $GITHUB_ENV
           echo "OPERATOR_YAML_NAME=${OPERATOR_YAML_NAME}" >> $GITHUB_ENV
-          
 
       - name: Generate Operator and Operator image
         working-directory: ./WORKDIR
@@ -154,7 +147,7 @@ jobs:
           echo "OPERATOR_IMAGE=${OPERATOR_IMAGE}" >> $GITHUB_ENV
 
           /operator-sdk init --plugins=helm --domain=''
-          /operator-sdk create api version=v1alpha1 --group=hazelcast.com --crd-version=v1beta1 --kind=${KIND} --helm-chart=$(pwd)/${NAME}
+          /operator-sdk create api version=v1alpha1 --group=hazelcast.com --crd-version=v1 --kind=${KIND} --helm-chart=$(pwd)/${NAME}
 
           cat >> watches.yaml <<EOL
             overrideValues:
@@ -164,7 +157,6 @@ jobs:
 
           echo "Building the operator image ${OPERATOR_IMAGE}"
           make docker-build  IMG=${OPERATOR_IMAGE}
-
 
       - name: Update Hazelcast-Operator files for testing
         run: |
@@ -189,12 +181,10 @@ jobs:
           name: hazelcast-operator
           path: ./artifact-hazelcast-operator
 
-
       - name: Set up Kubernetes in Docker
         uses: engineerd/setup-kind@v0.5.0
         with:
           version: "v0.11.1"
-
 
       - name: Deploy Hazelcast cluster
         run: |
@@ -216,11 +206,9 @@ jobs:
 
           kubectl apply -f hazelcast.yaml
 
-
       - name: Print log of the Hazelcast-Operator
         run: |
           kubectl logs -l app.kubernetes.io/name=${OPERATOR_NAME}
-
 
       - name: Validate cluster size
         run: |
@@ -237,11 +225,9 @@ jobs:
 
           verify_management_center $CLUSTER_SIZE
 
-
       - name: Copy Operatorhub bundle from the repo
         run: |
           cp -r ./operator-repo/.github/operator-release-files/operatorhub-bundle ./
-
 
       - name: Build Operatorhub bundle
         working-directory: .
@@ -265,19 +251,16 @@ jobs:
           cd ..
           sed -i "s/OPERATOR_VERSION/${OPERATOR_VERSION}/g" ${OPERATOR_NAME}.package.yaml
 
-
       - name: Upload Operatorhub bundle
         uses: actions/upload-artifact@v2
         with:
           name: operatorhub-bundle
           path: ./operatorhub-bundle-output
 
-
       - name: Push Hazelcast-Operator to Dockerhub
         run: |
           docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
           docker push ${OPERATOR_IMAGE}
-
 
       - name: Update Hazelcast versions in the repo Hazelcast-Operator
         working-directory: ./operator-repo
@@ -300,7 +283,6 @@ jobs:
           sed -i "s|hazelcast/${NAME}:.*|hazelcast/${NAME}:${HAZELCAST_VERSION}|" ./${OPERATOR_NAME}/${OPERATOR_YAML_NAME}.yaml
           sed -i "s|hazelcast/management-center:.*|hazelcast/management-center:${MANCENTER_VERSION}|" ./${OPERATOR_NAME}/${OPERATOR_YAML_NAME}.yaml
 
-
       - name: Commit changes done to Hazelcast-Operator
         working-directory: ./operator-repo
         run: |
@@ -313,7 +295,6 @@ jobs:
 
           git push -u origin ${OPERATOR_NAME}-file-updates-${{ github.run_id }}
 
-
       - name: Create a PR for changes in Hazelcast-Operator
         working-directory: ./operator-repo
         run: |
@@ -323,14 +304,12 @@ jobs:
               --title "Update image tags after release of ${OPERATOR_IMAGE}" \
               --body "Released ${OPERATOR_IMAGE} on Docker-Hub. This PR updates the image tags to new ones. "
 
-
       - name: Checkout to devOpsHelm/community-operators
         uses: actions/checkout@v2
         with:
           repository: devOpsHelm/community-operators
           path: community-operators
           token: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
-
 
       - name: Update main branch of the fork
         working-directory: community-operators
@@ -342,7 +321,6 @@ jobs:
           git pull upstream main 
 
           git push origin main
-
 
       - name: Create a PR for Operatorhub-bundle, k8s-operatorhub
         working-directory: community-operators
@@ -364,14 +342,12 @@ jobs:
 
           ../operator-repo/.github/scripts/expect.sh
 
-
       - name: Checkout to devOpsHelm/community-operators-prod
         uses: actions/checkout@v2
         with:
           repository: devOpsHelm/community-operators-prod
           path: community-operators-prod
           token: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
-
 
       - name: Update main branch of the fork
         working-directory: community-operators-prod
@@ -383,7 +359,6 @@ jobs:
           git pull upstream main 
 
           git push origin main
-
 
       - name: Create a PR for Operatorhub-bundle, redhat-openshift-ecosystem
         if: env.NAME == 'hazelcast'
@@ -406,10 +381,9 @@ jobs:
 
           ../operator-repo/.github/scripts/expect.sh
 
-
   slack_notify:
     name: Slack Notify
-    needs: build_publish 
+    needs: build_publish
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -418,6 +392,6 @@ jobs:
         with:
           fields: repo,commit,author,action,eventName,workflow
           status: ${{ needs.build_publish.result }}
-          channel: '#github-actions-log'
+          channel: "#github-actions-log"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/hazelcast-enterprise-operator/bundle-rhel.yaml
+++ b/hazelcast-enterprise-operator/bundle-rhel.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: hazelcastenterprises.hazelcast.com
@@ -11,13 +11,16 @@ spec:
     plural: hazelcastenterprises
     singular: hazelcastenterprise
   scope: Namespaced
-  version: v1alpha1
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-  subresources:
-    status: {}
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}
 
 ---
 apiVersion: v1
@@ -40,81 +43,81 @@ metadata:
     app.kubernetes.io/managed-by: hazelcast-enterprise-operator
 rules:
   - apiGroups:
-    - ""
+      - ""
     resources:
-    - pods
-    - services
-    - endpoints
-    - persistentvolumeclaims
-    - events
-    - configmaps
-    - secrets
+      - pods
+      - services
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
     verbs:
-    - '*'
+      - "*"
   - apiGroups:
-    - ""
-    - "extensions"
+      - ""
+      - "extensions"
     resources:
-    - ingresses
+      - ingresses
     verbs:
-    - '*'
+      - "*"
   - apiGroups:
-    - ""
+      - ""
     resources:
-    - namespaces
+      - namespaces
     verbs:
-    - get
+      - get
   - apiGroups:
-    - ""
+      - ""
     resources:
-    - serviceaccounts
+      - serviceaccounts
     verbs:
-    - get
-    - create
-    - list
-    - update
-    - delete
+      - get
+      - create
+      - list
+      - update
+      - delete
   - apiGroups:
-    - rbac.authorization.k8s.io
+      - rbac.authorization.k8s.io
     resources:
-    - roles
-    - rolebindings
+      - roles
+      - rolebindings
     verbs:
-    - get
-    - create
-    - list
-    - update
-    - delete
+      - get
+      - create
+      - list
+      - update
+      - delete
   - apiGroups:
-    - apps
+      - apps
     resources:
-    - deployments
-    - daemonsets
-    - replicasets
-    - statefulsets
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
     verbs:
-    - '*'
+      - "*"
   - apiGroups:
-    - monitoring.coreos.com
+      - monitoring.coreos.com
     resources:
-    - servicemonitors
+      - servicemonitors
     verbs:
-    - get
-    - create
+      - get
+      - create
   - apiGroups:
-    - apps
+      - apps
     resourceNames:
-    - hazelcast-enterprise-operator
+      - hazelcast-enterprise-operator
     resources:
-    - deployments/finalizers
+      - deployments/finalizers
     verbs:
-    - update
+      - update
   - apiGroups:
-    - hazelcast.com
+      - hazelcast.com
     resources:
-    - '*'
+      - "*"
     verbs:
-    - '*'
+      - "*"
 
 ---
 kind: RoleBinding
@@ -126,8 +129,8 @@ metadata:
     app.kubernetes.io/instance: hazelcast-enterprise-operator
     app.kubernetes.io/managed-by: hazelcast-enterprise-operator
 subjects:
-- kind: ServiceAccount
-  name: hazelcast-enterprise-operator
+  - kind: ServiceAccount
+    name: hazelcast-enterprise-operator
 roleRef:
   kind: ClusterRole
   name: hazelcast-enterprise-operator
@@ -162,16 +165,16 @@ spec:
       securityContext:
         capabilities:
           drop:
-          - ALL
+            - ALL
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
+              - matchExpressions:
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
       containers:
         - name: hazelcast-enterprise-operator
           image: registry.connect.redhat.com/hazelcast/hazelcast-enterprise-operator:0.3.6

--- a/hazelcast-enterprise-operator/bundle-rhel.yaml
+++ b/hazelcast-enterprise-operator/bundle-rhel.yaml
@@ -56,7 +56,7 @@ rules:
       - "*"
   - apiGroups:
       - ""
-      - "extensions"
+      - "networking.k8s.io"
     resources:
       - ingresses
     verbs:

--- a/hazelcast-enterprise-operator/bundle.yaml
+++ b/hazelcast-enterprise-operator/bundle.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: hazelcastenterprises.hazelcast.com
@@ -11,13 +11,16 @@ spec:
     plural: hazelcastenterprises
     singular: hazelcastenterprise
   scope: Namespaced
-  version: v1alpha1
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-  subresources:
-    status: {}
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}
 
 ---
 apiVersion: v1
@@ -40,81 +43,81 @@ metadata:
     app.kubernetes.io/managed-by: hazelcast-enterprise-operator
 rules:
   - apiGroups:
-    - ""
+      - ""
     resources:
-    - pods
-    - services
-    - endpoints
-    - persistentvolumeclaims
-    - events
-    - configmaps
-    - secrets
+      - pods
+      - services
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
     verbs:
-    - '*'
+      - "*"
   - apiGroups:
-    - ""
-    - "extensions"
+      - ""
+      - "extensions"
     resources:
-    - ingresses
+      - ingresses
     verbs:
-    - '*'
+      - "*"
   - apiGroups:
-    - ""
+      - ""
     resources:
-    - namespaces
+      - namespaces
     verbs:
-    - get
+      - get
   - apiGroups:
-    - ""
+      - ""
     resources:
-    - serviceaccounts
+      - serviceaccounts
     verbs:
-    - get
-    - create
-    - list
-    - update
-    - delete
+      - get
+      - create
+      - list
+      - update
+      - delete
   - apiGroups:
-    - rbac.authorization.k8s.io
+      - rbac.authorization.k8s.io
     resources:
-    - roles
-    - rolebindings
+      - roles
+      - rolebindings
     verbs:
-    - get
-    - create
-    - list
-    - update
-    - delete
+      - get
+      - create
+      - list
+      - update
+      - delete
   - apiGroups:
-    - apps
+      - apps
     resources:
-    - deployments
-    - daemonsets
-    - replicasets
-    - statefulsets
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
     verbs:
-    - '*'
+      - "*"
   - apiGroups:
-    - monitoring.coreos.com
+      - monitoring.coreos.com
     resources:
-    - servicemonitors
+      - servicemonitors
     verbs:
-    - get
-    - create
+      - get
+      - create
   - apiGroups:
-    - apps
+      - apps
     resourceNames:
-    - hazelcast-enterprise-operator
+      - hazelcast-enterprise-operator
     resources:
-    - deployments/finalizers
+      - deployments/finalizers
     verbs:
-    - update
+      - update
   - apiGroups:
-    - hazelcast.com
+      - hazelcast.com
     resources:
-    - '*'
+      - "*"
     verbs:
-    - '*'
+      - "*"
 
 ---
 kind: RoleBinding
@@ -126,8 +129,8 @@ metadata:
     app.kubernetes.io/instance: hazelcast-enterprise-operator
     app.kubernetes.io/managed-by: hazelcast-enterprise-operator
 subjects:
-- kind: ServiceAccount
-  name: hazelcast-enterprise-operator
+  - kind: ServiceAccount
+    name: hazelcast-enterprise-operator
 roleRef:
   kind: ClusterRole
   name: hazelcast-enterprise-operator
@@ -162,16 +165,16 @@ spec:
       securityContext:
         capabilities:
           drop:
-          - ALL
+            - ALL
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
+              - matchExpressions:
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
       containers:
         - name: hazelcast-enterprise-operator
           image: hazelcast/hazelcast-enterprise-operator:0.3.6

--- a/hazelcast-enterprise-operator/bundle.yaml
+++ b/hazelcast-enterprise-operator/bundle.yaml
@@ -56,7 +56,7 @@ rules:
       - "*"
   - apiGroups:
       - ""
-      - "extensions"
+      - "networking.k8s.io"
     resources:
       - ingresses
     verbs:

--- a/hazelcast-enterprise-operator/hazelcastcluster.crd.yaml
+++ b/hazelcast-enterprise-operator/hazelcastcluster.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: hazelcastenterprises.hazelcast.com
@@ -10,10 +10,13 @@ spec:
     plural: hazelcastenterprises
     singular: hazelcastenterprise
   scope: Namespaced
-  version: v1alpha1
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-  subresources:
-    status: {}
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}

--- a/hazelcast-enterprise-operator/operator-rbac.yaml
+++ b/hazelcast-enterprise-operator/operator-rbac.yaml
@@ -32,7 +32,7 @@ rules:
     - '*'
   - apiGroups:
     - ""
-    - "extensions"
+    - "networking.k8s.io"
     resources:
     - ingresses
     verbs:

--- a/hazelcast-operator/bundle.yaml
+++ b/hazelcast-operator/bundle.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: hazelcasts.hazelcast.com
@@ -11,13 +11,16 @@ spec:
     plural: hazelcasts
     singular: hazelcast
   scope: Namespaced
-  version: v1alpha1
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-  subresources:
-    status: {}
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}
 
 ---
 apiVersion: v1
@@ -40,81 +43,81 @@ metadata:
     app.kubernetes.io/managed-by: hazelcast-operator
 rules:
   - apiGroups:
-    - ""
+      - ""
     resources:
-    - pods
-    - services
-    - endpoints
-    - persistentvolumeclaims
-    - events
-    - configmaps
-    - secrets
+      - pods
+      - services
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
     verbs:
-    - '*'
+      - "*"
   - apiGroups:
-    - ""
-    - "extensions"
+      - ""
+      - "extensions"
     resources:
-    - ingresses
+      - ingresses
     verbs:
-    - '*'
+      - "*"
   - apiGroups:
-    - ""
+      - ""
     resources:
-    - namespaces
+      - namespaces
     verbs:
-    - get
+      - get
   - apiGroups:
-    - ""
+      - ""
     resources:
-    - serviceaccounts
+      - serviceaccounts
     verbs:
-    - get
-    - create
-    - list
-    - update
-    - delete
+      - get
+      - create
+      - list
+      - update
+      - delete
   - apiGroups:
-    - rbac.authorization.k8s.io
+      - rbac.authorization.k8s.io
     resources:
-    - roles
-    - rolebindings
+      - roles
+      - rolebindings
     verbs:
-    - get
-    - create
-    - list
-    - update
-    - delete
+      - get
+      - create
+      - list
+      - update
+      - delete
   - apiGroups:
-    - apps
+      - apps
     resources:
-    - deployments
-    - daemonsets
-    - replicasets
-    - statefulsets
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
     verbs:
-    - '*'
+      - "*"
   - apiGroups:
-    - monitoring.coreos.com
+      - monitoring.coreos.com
     resources:
-    - servicemonitors
+      - servicemonitors
     verbs:
-    - get
-    - create
+      - get
+      - create
   - apiGroups:
-    - apps
+      - apps
     resourceNames:
-    - hazelcast-operator
+      - hazelcast-operator
     resources:
-    - deployments/finalizers
+      - deployments/finalizers
     verbs:
-    - update
+      - update
   - apiGroups:
-    - hazelcast.com
+      - hazelcast.com
     resources:
-    - '*'
+      - "*"
     verbs:
-    - '*'
+      - "*"
 
 ---
 kind: RoleBinding
@@ -126,8 +129,8 @@ metadata:
     app.kubernetes.io/instance: hazelcast-operator
     app.kubernetes.io/managed-by: hazelcast-operator
 subjects:
-- kind: ServiceAccount
-  name: hazelcast-operator
+  - kind: ServiceAccount
+    name: hazelcast-operator
 roleRef:
   kind: ClusterRole
   name: hazelcast-operator
@@ -162,16 +165,16 @@ spec:
       securityContext:
         capabilities:
           drop:
-          - ALL
+            - ALL
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
+              - matchExpressions:
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
       containers:
         - name: hazelcast-operator
           image: hazelcast/hazelcast-operator:0.3.6

--- a/hazelcast-operator/bundle.yaml
+++ b/hazelcast-operator/bundle.yaml
@@ -56,7 +56,7 @@ rules:
       - "*"
   - apiGroups:
       - ""
-      - "extensions"
+      - "networking.k8s.io"
     resources:
       - ingresses
     verbs:

--- a/hazelcast-operator/hazelcastcluster.crd.yaml
+++ b/hazelcast-operator/hazelcastcluster.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: hazelcasts.hazelcast.com
@@ -10,10 +10,13 @@ spec:
     plural: hazelcasts
     singular: hazelcast
   scope: Namespaced
-  version: v1alpha1
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-  subresources:
-    status: {}
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}

--- a/hazelcast-operator/operator-rbac.yaml
+++ b/hazelcast-operator/operator-rbac.yaml
@@ -32,7 +32,7 @@ rules:
     - '*'
   - apiGroups:
     - ""
-    - "extensions"
+    - "networking.k8s.io"
     resources:
     - ingresses
     verbs:


### PR DESCRIPTION
Changes
- Updated Hazelcast CRD apiVersion to v1 and changed its spec using guidelines explained [here](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122) 
- Updated release scripts to use CRD version v1
- Updated apiGroup of ingress to `networking.k8s.io` in ClusterRole manifests.

Tested the Operator in GKE Kubernetes version 1.21 and Minikube Kubernetes version 1.22.