### PR TITLE
Double quote Hazelcast EE and MC image tags in yaml files

### DIFF
--- a/.github/workflows/hz-enterprise-op-rhel-release.yaml
+++ b/.github/workflows/hz-enterprise-op-rhel-release.yaml
@@ -175,8 +175,8 @@ jobs:
         run: |
           cp -r ./operator-repo/${OPERATOR_NAME}  ./
 
-          sed -i "0,/tag: .*/s__tag: ${HAZELCAST_VERSION}_" ./${OPERATOR_NAME}/hazelcast.yaml
-          sed -i "0,/tag: /! s/tag: .*/tag: ${MANCENTER_VERSION}/" ./${OPERATOR_NAME}/hazelcast.yaml
+          sed -i "0,/tag: .*/s//tag: \"${HAZELCAST_VERSION}\"/" ./${OPERATOR_NAME}/hazelcast.yaml
+          sed -i "0,/tag: /! s/tag: .*/tag: \"${MANCENTER_VERSION}\"/" ./${OPERATOR_NAME}/hazelcast.yaml
 
           sed -i "0,/repository: .*/s||repository: ${RHEL_HAZELCAST_REPO}|" ./${OPERATOR_NAME}/hazelcast.yaml
           sed -i "0,/repository: /! s|repository: .*|repository: ${RHEL_MANCENTER_REPO}|" ./${OPERATOR_NAME}/hazelcast.yaml

--- a/.github/workflows/hz-op-dockerhub-release.yml
+++ b/.github/workflows/hz-op-dockerhub-release.yml
@@ -162,8 +162,8 @@ jobs:
         run: |
           cp -r ./operator-repo/${OPERATOR_NAME}  ./
 
-          sed -i "0,/tag: .*/s//tag: ${HAZELCAST_VERSION}/" ./${OPERATOR_NAME}/hazelcast.yaml
-          sed -i "0,/tag: /! s/tag: .*/tag: ${MANCENTER_VERSION}/" ./${OPERATOR_NAME}/hazelcast.yaml
+          sed -i "0,/tag: .*/s//tag: \"${HAZELCAST_VERSION}\"/" ./${OPERATOR_NAME}/hazelcast.yaml
+          sed -i "0,/tag: /! s/tag: .*/tag: \"${MANCENTER_VERSION}\"/" ./${OPERATOR_NAME}/hazelcast.yaml
 
           sed -i "s/imagePullPolicy: .*/imagePullPolicy: Never/g" ./${OPERATOR_NAME}/bundle.yaml
           sed -i "s/productVersion: .*/productVersion: ${OPERATOR_VERSION}/g" ./${OPERATOR_NAME}/bundle.yaml
@@ -265,8 +265,8 @@ jobs:
       - name: Update Hazelcast versions in the repo Hazelcast-Operator
         working-directory: ./operator-repo
         run: |
-          sed -i "0,/tag: .*/s//tag: ${HAZELCAST_VERSION}/" ./${OPERATOR_NAME}/hazelcast.yaml
-          sed -i "0,/tag: /! s/tag: .*/tag: ${MANCENTER_VERSION}/" ./${OPERATOR_NAME}/hazelcast.yaml
+          sed -i "0,/tag: .*/s//tag: \"${HAZELCAST_VERSION}\"/" ./${OPERATOR_NAME}/hazelcast.yaml
+          sed -i "0,/tag: /! s/tag: .*/tag: \"${MANCENTER_VERSION}\"/" ./${OPERATOR_NAME}/hazelcast.yaml
 
           sed -i "0,/tag: .*/s//tag: \"${HAZELCAST_VERSION}\"/" ./${OPERATOR_NAME}/hazelcast-full.yaml
           sed -i "0,/tag: /! s/tag: .*/tag: \"${MANCENTER_VERSION}\"/" ./${OPERATOR_NAME}/hazelcast-full.yaml


### PR DESCRIPTION
This is done due to yaml conversion versions 5.0, 6.0 etc. to integers because they are not quoted.